### PR TITLE
fix: postinstall scripts module

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "native/index.node",
-    "lib"
+    "lib",
+    "scripts"
   ],
   "binary": {
     "module_name": "index",


### PR DESCRIPTION
Fixes 'Cannot find module' if running: `npm install --save maidsafe/safe-nodejs.git`

Include `scripts` directory to enable `postinstall` to run on installing this package.